### PR TITLE
multi: rework request rate limiting.

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -56,7 +56,6 @@ debuglevel=debug
 homedir=.
 port=:19576
 activenet=simnet
-miningaddrs=${WALLET_MINING_ADDR}
 poolfeeaddrs=${WALLET_POOL_FEE_ADDR}
 EOF
 cat > "${NODES_ROOT}/client.conf" <<EOF

--- a/network/hub.go
+++ b/network/hub.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"dnldd/dcrpool/database"
 	"math/big"
 	"math/rand"
 	"net/http"
@@ -23,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"dnldd/dcrpool/database"
 	"dnldd/dcrpool/dividend"
 )
 
@@ -219,8 +219,9 @@ func NewHub(db *bolt.DB, httpc *http.Client, hcfg *HubConfig, limiter *RateLimit
 		return nil, err
 	}
 
-	h.grpc = walletrpc.NewWalletServiceClient(h.gConn)
 	log.Debugf("GRPC connection established with dcrwallet.")
+
+	h.grpc = walletrpc.NewWalletServiceClient(h.gConn)
 
 	h.StartPaymentCron()
 

--- a/network/limiter.go
+++ b/network/limiter.go
@@ -8,10 +8,16 @@ import (
 )
 
 const (
-	// tokenRate is the token usage allowed per second.
-	tokenRate = 4
+	// For a connected client within fifteen (15) seconds three (3) ping
+	// responses and a submit work request. The current limiter settings
+	// allows for thirty (30) tokens generated every fifteen (15) seconds.
+	// This should be enough for the requests of the connected client as
+	// well as requests vai the pool API.
+
+	// tokenRate is the token refill rate for the bucket per second.
+	tokenRate = 2
 	// burst is the maximum token usage allowed per call.
-	burst = 2
+	burst = 3
 )
 
 // RequestLimiter represents a rate limiter for a connecting client. This identifies

--- a/network/message.go
+++ b/network/message.go
@@ -12,9 +12,13 @@ const (
 	NotificationType = "notification"
 )
 
-// Thresholds.
 const (
-	MaxMessageSize = 1024
+	// MaxMessageSize represents the maximum message expected from clients,
+	// currently it is a work message.
+	MaxMessageSize = 511
+
+	// MaxPingRetries represents the maximum number of unanswered ping requests
+	// by a client before disconnection.
 	MaxPingRetries = 3
 )
 
@@ -27,6 +31,7 @@ const (
 	EvaluatedWork     = "evaluatedwork"
 	ConnectedBlock    = "connectedblock"
 	DisconnectedBlock = "disconnectedblock"
+	TooManyRequests   = "toomanyrequests"
 )
 
 // Message is the base interface messages exchanged between a websocket client
@@ -114,6 +119,21 @@ func tooManyRequestsResponse(id *uint64) *Response {
 		Error:  &err,
 		Result: nil,
 	}
+}
+
+// ParseTooManyRequestsResponse parses a too many requests response.
+func ParseTooManyRequestsResponse(resp *Response) error {
+	if resp.ID == nil {
+		return errors.New("Invalid too many requests response, " +
+			"'should have 'id' field set")
+	}
+
+	if resp.Error == nil {
+		return errors.New("Invalid too many requests response, " +
+			"should have 'error' field set")
+	}
+
+	return nil
 }
 
 // WorkNotification is a convenience function for creating a work notification.

--- a/poolclient/client.go
+++ b/poolclient/client.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/websocket"
 
 	"dnldd/dcrpool/dividend"
@@ -157,7 +158,15 @@ out:
 			method := pc.fetchRequest(*resp.ID)
 			if method == "" {
 				log.Error("No request found for received response "+
-					" with id: ", *resp.ID)
+					"with id: ", *resp.ID, spew.Sdump(resp))
+				continue
+			}
+
+			// If the response is a too many requests response, remove the
+			// request entry and continue.
+			err := network.ParseTooManyRequestsResponse(resp)
+			if err == nil {
+				pc.deleteRequest(*resp.ID)
 				continue
 			}
 


### PR DESCRIPTION
This fixes a couple of bugs in the rate limiting code, sets the maximum message size and applies it as the read limit. It also properly handles too many request messages to clients.