### PR TITLE
multi: add target conversion tests.

### DIFF
--- a/dividend/share_test.go
+++ b/dividend/share_test.go
@@ -1,6 +1,7 @@
 package dividend
 
 import (
+	"github.com/decred/dcrd/chaincfg"
 	"math/big"
 	"os"
 	"testing"
@@ -12,7 +13,7 @@ import (
 )
 
 var (
-	// TestDB reprsents the testing database.
+	// TestDB represents the testing database.
 	TestDB = "testdb"
 )
 
@@ -229,6 +230,7 @@ func TestCalculateDividend(t *testing.T) {
 		}
 	}
 }
+
 func TestCalculatePoolTarget(t *testing.T) {
 	set := []struct {
 		hashRate   *big.Int
@@ -238,19 +240,22 @@ func TestCalculatePoolTarget(t *testing.T) {
 		{
 			new(big.Int).SetInt64(1.2E12),
 			new(big.Int).SetInt64(15),
-			"1381437475988024283268563409791075016144953" +
-				"2887812045339949604391304358105",
+			"6432893846517566412420610278260439325181665814757809113303199112",
 		},
 		{
 			new(big.Int).SetInt64(1.2E12),
 			new(big.Int).SetInt64(10),
-			"2072156213982036424902845114686612524217429" +
-				"9331718068009924406586956537158",
+			"9649340769776349618630915417390658987772498722136713669954798668",
 		},
 	}
 
 	for _, test := range set {
-		target := CalculatePoolTarget(test.hashRate, test.targetTime)
+		target, err := CalculatePoolTarget(&chaincfg.SimNetParams,
+			test.hashRate, test.targetTime)
+		if err != nil {
+			t.Error(err)
+		}
+
 		expected, success := new(big.Int).SetString(test.expected, 10)
 		if !success {
 			t.Errorf("Failed to parse (%v) as a big.Int", test.expected)

--- a/go.mod
+++ b/go.mod
@@ -25,14 +25,16 @@ require (
 	google.golang.org/grpc v1.15.0
 )
 
-replace github.com/decred/dcrd/blockchain => ../dcrd/blockchain
+replace (
+	github.com/decred/dcrd/blockchain => ../dcrd/blockchain
 
-replace github.com/decred/dcrd/dcrutil => ../dcrd/dcrutil
+	github.com/decred/dcrd/chaincfg => ../dcrd/chaincfg
 
-replace github.com/decred/dcrd/rpcclient => ../dcrd/rpcclient
+	github.com/decred/dcrd/dcrjson => ../dcrd/dcrjson
 
-replace github.com/decred/dcrd/wire => ../dcrd/wire
+	github.com/decred/dcrd/dcrutil => ../dcrd/dcrutil
 
-replace github.com/decred/dcrd/dcrjson => ../dcrd/dcrjson
+	github.com/decred/dcrd/rpcclient => ../dcrd/rpcclient
 
-replace github.com/decred/dcrd/chaincfg => ../dcrd/chaincfg
+	github.com/decred/dcrd/wire => ../dcrd/wire
+)

--- a/network/client.go
+++ b/network/client.go
@@ -74,10 +74,10 @@ func (c *Client) claimWeightedShare() {
 	share.Create(c.hub.db)
 }
 
-// bigToLEUint256 returns the passed big integer as an unsigned 256-bit integer
+// BigToLEUint256 returns the passed big integer as an unsigned 256-bit integer
 // encoded as little-endian bytes.  Numbers which are larger than the max
 // unsigned 256-bit integer are truncated.
-func bigToLEUint256(n *big.Int) [uint256Size]byte {
+func BigToLEUint256(n *big.Int) [uint256Size]byte {
 	// Pad or truncate the big-endian big int to correct number of bytes.
 	nBytes := n.Bytes()
 	nlen := len(nBytes)
@@ -96,6 +96,22 @@ func bigToLEUint256(n *big.Int) [uint256Size]byte {
 		buf[i], buf[uint256Size-1-i] = buf[uint256Size-1-i], buf[i]
 	}
 	return buf
+}
+
+// LEUint256ToBig returns the passed unsigned 256-bit integer
+// encoded as little-endian as a big integer.
+func LEUint256ToBig(n [uint256Size]byte) *big.Int {
+	var buf [uint256Size]byte
+	copy(buf[:], n[:])
+
+	// Reverse the bytes to big endian and create a big.Int.
+	for i := 0; i < uint256Size/2; i++ {
+		buf[i], buf[uint256Size-1-i] = buf[uint256Size-1-i], buf[i]
+	}
+
+	v := new(big.Int).SetBytes(buf[:])
+
+	return v
 }
 
 // NewClient initializes a new websocket client.
@@ -338,7 +354,7 @@ out:
 
 				// Covert the pool target to little endian hex encoded byte
 				// slice.
-				targetLE := bigToLEUint256(blockchain.CompactToBig(target))
+				targetLE := BigToLEUint256(blockchain.CompactToBig(target))
 				t := hex.EncodeToString(targetLE[:])
 
 				// Send an updated work notification per the client's miner type.

--- a/network/conversion_test.go
+++ b/network/conversion_test.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/blockchain"
+	"github.com/decred/dcrd/chaincfg"
+
+	"dnldd/dcrpool/dividend"
+)
+
+func TestTargetConversion(t *testing.T) {
+	targetTime := new(big.Int).SetInt64(15)
+	for miner, hashrate := range dividend.MinerHashes {
+		target, err := dividend.CalculatePoolTarget(&chaincfg.SimNetParams,
+			hashrate, targetTime)
+		if err != nil {
+			t.Error(err)
+		}
+
+		compact := blockchain.BigToCompact(target)
+		leu256 := BigToLEUint256(target)
+		cBig := LEUint256ToBig(leu256)
+		if target.Cmp(cBig) != 0 {
+			t.Errorf("invalid LEUint256 to big.Int conversion (%v) expected "+
+				"%v, got %v", miner, target, cBig)
+		}
+
+		cCompact := blockchain.BigToCompact(cBig)
+		if cCompact != compact {
+			t.Errorf("invalid big.Int to uint32 conversion (%v) expected "+
+				"%v, got %v", miner, target, cBig)
+		}
+	}
+}

--- a/network/hub.go
+++ b/network/hub.go
@@ -88,7 +88,13 @@ func NewHub(db *bolt.DB, httpc *http.Client, hcfg *HubConfig, limiter *RateLimit
 	// Calculate pool targets for all known miners.
 	h.poolTargetsMtx.Lock()
 	for miner, hashrate := range dividend.MinerHashes {
-		target := dividend.CalculatePoolTarget(hashrate, h.cfg.MaxGenTime)
+		target, err := dividend.CalculatePoolTarget(h.cfg.ActiveNet, hashrate,
+			h.cfg.MaxGenTime)
+		if err != nil {
+			log.Error(err)
+			return nil, err
+		}
+
 		compactTarget := blockchain.BigToCompact(target)
 		h.poolTargets[miner] = compactTarget
 	}


### PR DESCRIPTION
Target conversion helpers and  tests have been added as well as fixes to bugs with the pool target calculation, the active network is also incorporated. The CPU miner has also been updated to convert provided targets from work notifications and use that instead of the header bits.