### PR TITLE
multi: add cursor iteration/deletion test.

### DIFF
--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -469,7 +469,7 @@ func TestPaymentsMaturity(t *testing.T) {
 		t.Error(err)
 	}
 
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 200)
 
 	yNano := time.Now().UnixNano()
 	err = createMultiplePersistedShares(db, yID, weight, yNano, shareCount)


### PR DESCRIPTION
This adds a cursor iteration/deletion test and updates call sites accordingly. Test assertions for PPSEligibleShares have also been simplified.