### PR TITLE
multi: revert to deletion via buckets.

### DIFF
--- a/dividend/share_test.go
+++ b/dividend/share_test.go
@@ -358,6 +358,9 @@ func TestCalculatePoolTarget(t *testing.T) {
 	}
 }
 
+// Currently not using cursor delete's even though this test passing. An
+// identical test in a PR for dcrwallet is failing, inconsistent
+// behaviour.
 func TestBoltDBCursorDeletion(t *testing.T) {
 	db, err := setupDB()
 	if err != nil {

--- a/network/job.go
+++ b/network/job.go
@@ -127,6 +127,7 @@ func PruneJobs(db *bolt.DB, height uint32) error {
 			return database.ErrBucketNotFound(database.JobBkt)
 		}
 
+		toDelete := [][]byte{}
 		c := bkt.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			height, err := hex.DecodeString(string(k[:8]))
@@ -135,10 +136,14 @@ func PruneJobs(db *bolt.DB, height uint32) error {
 			}
 
 			if bytes.Compare(height, heightBE) <= 0 {
-				err := c.Delete()
-				if err != nil {
-					return err
-				}
+				toDelete = append(toDelete, k)
+			}
+		}
+
+		for _, entry := range toDelete {
+			err := bkt.Delete(entry)
+			if err != nil {
+				return err
 			}
 		}
 


### PR DESCRIPTION
This fixes a bug with `PruneAcceptedWork` and reverts deletion via cursors to deletion via buckets due to
inconsistent behaviour noticed with an identical test on dcrwallet. Deletion via buckets is the safest option since it's been tested in production.