### PR TITLE
multi: use higher share gen. time in solo pool mode.

### DIFF
--- a/dividend/share.go
+++ b/dividend/share.go
@@ -68,8 +68,8 @@ var MinerHashes = map[string]*big.Int{
 	// ObeliskDCR1:   new(big.Int).SetInt64(2.6E12),
 	AntminerDR3: new(big.Int).SetInt64(7.8E12),
 	// StrongUU1:     new(big.Int).SetInt64(12E12),
-	AntminerDR5:  new(big.Int).SetInt64(32E12),
-	WhatsminerD1: new(big.Int).SetInt64(44E12),
+	AntminerDR5:  new(big.Int).SetInt64(35E12),
+	WhatsminerD1: new(big.Int).SetInt64(48E12),
 }
 
 // MinerPorts is a map of all known DCR miners and the coressponding


### PR DESCRIPTION
This updates the pool diff helper to use 25 seconds as the max gen. time when calculating the appropriate
diffs for pool clients in solo pool mode where valid shares are a non-factor. The max gen. time was was kept under 30 seconds due to the likelihood of pool clients having timeouts of 30 seconds when there is no activity. This also updates the hashrates of the DR5 and D1.