### PR TITLE
multi: add mined blocks counter.

### DIFF
--- a/dividend/share.go
+++ b/dividend/share.go
@@ -65,9 +65,8 @@ func fetchPOWLimit(net *chaincfg.Params) (*big.Int, error) {
 var MinerHashes = map[string]*big.Int{
 	CPU:           new(big.Int).SetInt64(150E3),
 	InnosiliconD9: new(big.Int).SetInt64(2.4E12),
-	// ObeliskDCR1:   new(big.Int).SetInt64(2.6E12),
-	AntminerDR3: new(big.Int).SetInt64(7.8E12),
-	// StrongUU1:     new(big.Int).SetInt64(12E12),
+	// ObeliskDCR1:   new(big.Int).SetInt64(1.1E12),
+	AntminerDR3:  new(big.Int).SetInt64(7.8E12),
 	AntminerDR5:  new(big.Int).SetInt64(35E12),
 	WhatsminerD1: new(big.Int).SetInt64(48E12),
 }
@@ -80,8 +79,7 @@ var MinerPorts = map[string]uint32{
 	InnosiliconD9: 5552,
 	AntminerDR3:   5553,
 	AntminerDR5:   5554,
-	// StrongUU1:     5554,
-	WhatsminerD1: 5555,
+	WhatsminerD1:  5555,
 }
 
 // Convenience variables.
@@ -106,13 +104,12 @@ var (
 // rest were calculated as :
 // 				(Hash of Miner X * Weight of LHM)/ Hash of LHM
 var ShareWeights = map[string]*big.Rat{
-	CPU:           new(big.Rat).SetFloat64(0.0), // Reserved for testing.
-	InnosiliconD9: new(big.Rat).SetFloat64(1.0),
-	// ObeliskDCR1:   new(big.Rat).SetFloat64(1.0833),
-	AntminerDR3: new(big.Rat).SetFloat64(3.25),
-	// StrongUU1:     new(big.Rat).SetFloat64(5),
-	AntminerDR5:  new(big.Rat).SetFloat64(11.429),
-	WhatsminerD1: new(big.Rat).SetFloat64(18.333),
+	CPU: new(big.Rat).SetFloat64(0.0), // Reserved for testing.
+	// ObeliskDCR1:   new(big.Rat).SetFloat64(1.0),
+	InnosiliconD9: new(big.Rat).SetFloat64(2.182),
+	AntminerDR3:   new(big.Rat).SetFloat64(7.091),
+	AntminerDR5:   new(big.Rat).SetFloat64(31.181),
+	WhatsminerD1:  new(big.Rat).SetFloat64(43.636),
 }
 
 // CalculatePoolDifficulty determines the difficulty at which the provided

--- a/miner/cpuminer.go
+++ b/miner/cpuminer.go
@@ -130,10 +130,11 @@ func (m *CPUMiner) solveBlock(headerB []byte, target *big.Int, ticker *time.Tick
 					return false
 				}
 
-				hash := header.BlockHash()
+				log.Tracef("Reconstructed block header is: %v", spew.Sdump(header))
 
 				// A valid submission is generated when the block hash is less
 				// than the pool target of the client.
+				hash := header.BlockHash()
 				hashNum := blockchain.HashToBig(&hash)
 				hashesCompleted++
 

--- a/network/message.go
+++ b/network/message.go
@@ -428,13 +428,11 @@ func ParseWorkNotification(req *Request) (string, string, string, string, string
 
 // GenerateBlockHeader creates a block header from a mining.notify
 // message and the extraNonce1 of the client.
-func GenerateBlockHeader(blockVersionE string, prevBlockE string, genTx1E string, nTimeE string, extraNonce1E string, genTx2E string) (*wire.BlockHeader, error) {
+func GenerateBlockHeader(blockVersionE string, prevBlockE string, genTx1E string, extraNonce1E string, genTx2E string) (*wire.BlockHeader, error) {
 	buf := bytes.NewBufferString("")
 	buf.WriteString(blockVersionE)
 	buf.WriteString(prevBlockE)
 	buf.WriteString(genTx1E)
-	buf.WriteString(nTimeE)
-	buf.WriteString(strings.Repeat("0", 8))
 	buf.WriteString(extraNonce1E)
 	buf.WriteString(strings.Repeat("0", 56))
 	buf.WriteString(genTx2E)


### PR DESCRIPTION
This refactors some helpers and the cpu miner. Share weights have been updated due to the updated hashrate of the DCR1. The getwork handler has been tweaked to try and fetch new work in 5 second intervals. Lastly the pool now tracks the mined blocks count.