### PR TITLE
multi: handle pool mode switches.

### DIFF
--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -95,7 +95,7 @@ func TestPayPerShare(t *testing.T) {
 			return database.ErrBucketNotFound(database.PoolBkt)
 		}
 
-		lastPaymentCreatedOn = pbkt.Get(LastPaymentCreatedOn)
+		lastPaymentCreatedOn = pbkt.Get(database.LastPaymentCreatedOn)
 		return nil
 	})
 
@@ -228,7 +228,7 @@ func TestPayPerLastShare(t *testing.T) {
 			return database.ErrBucketNotFound(database.PoolBkt)
 		}
 
-		lastPaymentCreatedOn = pbkt.Get(LastPaymentCreatedOn)
+		lastPaymentCreatedOn = pbkt.Get(database.LastPaymentCreatedOn)
 		return nil
 	})
 

--- a/network/acceptedwork.go
+++ b/network/acceptedwork.go
@@ -186,7 +186,7 @@ func ListMinedWork(db *bolt.DB, page uint32) ([]*AcceptedWork, uint32, error) {
 
 		// return an empty list if the mined block counter has not been
 		// initialized.
-		v := pbkt.Get(MinedBlocks)
+		v := pbkt.Get(database.MinedBlocks)
 		if v == nil {
 			return nil
 		}
@@ -263,7 +263,7 @@ func ListMinedWorkByAccount(db *bolt.DB, accountID string) ([]*AcceptedWork, err
 
 		// return an empty list if the mined block counter is has not been
 		// initialized.
-		v := pbkt.Get(MinedBlocks)
+		v := pbkt.Get(database.MinedBlocks)
 		if v == nil {
 			return nil
 		}

--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -16,6 +16,7 @@ const (
 
 	// MaxMessageSize represents the maximum size of a transmitted message,
 	// in bytes.
+	// TODO: factor in
 	MaxMessageSize = 511
 )
 


### PR DESCRIPTION
This tracks pool mode switches and backs up the db if necessary. Some refactoring has been done to
persist tracked values as they change instead of waiting till shutdown. Bugs related to persisting kvs
have also been resolved. New apis reporting the last work height and the last payment height have also been added.