### PR TITLE
network: enforce max message size.

### DIFF
--- a/network/endpoint.go
+++ b/network/endpoint.go
@@ -13,11 +13,6 @@ import (
 const (
 	// TCP represents the tcp network protocol.
 	TCP = "tcp"
-
-	// MaxMessageSize represents the maximum size of a transmitted message,
-	// in bytes.
-	// TODO: factor in
-	MaxMessageSize = 511
 )
 
 // Endpoint represents a stratum endpoint.

--- a/network/hub.go
+++ b/network/hub.go
@@ -546,7 +546,7 @@ func (h *Hub) PublishTransaction(payouts map[dcrutil.Address]dcrutil.Amount, tar
 // handleGetWork periodically fetches available work from the consensus daemon.
 func (h *Hub) handleGetWork() {
 	var currHeaderE string
-	ticker := time.NewTicker(time.Second * 5)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	log.Info("Started getwork handler")
 
@@ -1082,8 +1082,9 @@ func (h *Hub) FetchMinedWork(w http.ResponseWriter, r *http.Request) {
 // based on work contributed per the peyment scheme used by the pool.
 func (h *Hub) FetchWorkQuotas(w http.ResponseWriter, r *http.Request) {
 	if h.cfg.SoloPool {
-		RespondWithError(w, http.StatusBadRequest, "share percentages not "+
-			"available when mining in solo pool mode")
+		RespondWithJSON(w, http.StatusOK, map[string]string{
+			"response": "share percentages not available when mining" +
+				" in solo pool mode"})
 		return
 	}
 


### PR DESCRIPTION
This enforces the max message size for a client's reader and reduces the ticker of the getwork handler to 1 second.