### PR TITLE
multi: update mined work tracking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,18 @@ payload: {
 	"address": "xxx" - the account address.
 }
 
-GET /mined/{page} - paginated list of mined blocks by the pool.
+GET /mined - list of mined blocks by the pool.
 
 POST /account/payments [pooled mining call] - list of payments made to the provided account.
 payload: {
 	"name":"xxx", - the account name.
 	"address": "xxx", - the account address.
 	"min": xxxx - the minimum payment time, in seconds, unix time.
+}
+
+POST /backup - database backup.
+payload: {
+	"pass":"xxx" - the backup password.
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -96,6 +96,7 @@ type config struct {
 	WalletPass      string   `long:"walletpass" description:"The wallet passphrase."`
 	MinPayment      float64  `long:"minpayment" description:"The minimum payment to process for an account."`
 	SoloPool        bool     `long:"solopool" description:"Solo pool mode. This disables payment processing when enabled."`
+	BackupPass      string   `long:"backuppass" description:"The backup password, required for backup over api"`
 	poolFeeAddrs    []dcrutil.Address
 	dcrdRPCCerts    []byte
 	net             *chaincfg.Params
@@ -388,6 +389,13 @@ func loadConfig() (*config, []string, error) {
 	// Initialize log rotation.  After log rotation has been initialized, the
 	// logger variables may be used.
 	initLogRotator(filepath.Join(cfg.LogDir, defaultLogFilename))
+
+	// Ensure the backup password is set.
+	if cfg.BackupPass == "" {
+		str := "%s: backup password not set"
+		err := fmt.Errorf(str, funcName)
+		return nil, nil, err
+	}
 
 	// Create the data directory.
 	err = os.MkdirAll(cfg.DataDir, 0700)

--- a/database/db.go
+++ b/database/db.go
@@ -27,13 +27,10 @@ var (
 	// current chain tip height.
 	JobBkt = []byte("jobbkt")
 
-	// WorkBkt stores work submissions from the pool accepted by the network,
-	// it is periodically pruned by the current chain tip  adjusted by the
-	// max reorg height and by chain reorgs.
+	// WorkBkt stores work submissions from pool clients and confirmed mined
+	// work from the pool, it is periodically pruned by the current chain tip
+	// adjusted by the max reorg height and by chain reorgs.
 	WorkBkt = []byte("workbkt")
-
-	// MinedBkt stores mined blocks by pool, it is pruned by chain reorgs.
-	MinedBkt = []byte("minedbkt")
 
 	// PaymentBkt stores all payments.
 	PaymentBkt = []byte("paymentbkt")
@@ -57,9 +54,6 @@ var (
 
 	// TxFeeReserve is the key of the tx fee reserve.
 	TxFeeReserve = []byte("txfeereserve")
-
-	// MinedBlocks is the mined block count key.
-	MinedBlocks = []byte("minedblocks")
 
 	// SoloPool is the solo pool mode key.
 	SoloPool = []byte("solopool")
@@ -135,12 +129,6 @@ func CreateBuckets(db *bolt.DB) error {
 				string(JobBkt), err)
 		}
 
-		_, err = pbkt.CreateBucketIfNotExists(MinedBkt)
-		if err != nil {
-			return fmt.Errorf("failed to create '%v' bucket: %v",
-				string(MinedBkt), err)
-		}
-
 		_, err = pbkt.CreateBucketIfNotExists(PaymentBkt)
 		if err != nil {
 			return fmt.Errorf("failed to create '%v' bucket: %v",
@@ -172,7 +160,7 @@ func Delete(db *bolt.DB, bucket, key []byte) error {
 	return err
 }
 
-// Backup saves a copy of the db file.
+// Backup saves a copy of the db to file.
 func Backup(db *bolt.DB) error {
 	// Backup the db file
 	err := db.View(func(tx *bolt.Tx) error {
@@ -217,12 +205,6 @@ func Purge(db *bolt.DB) error {
 				string(JobBkt), err)
 		}
 
-		err = pbkt.DeleteBucket(MinedBkt)
-		if err != nil {
-			return fmt.Errorf("failed to delete '%v' bucket: %v",
-				string(MinedBkt), err)
-		}
-
 		err = pbkt.DeleteBucket(PaymentBkt)
 		if err != nil {
 			return fmt.Errorf("failed to delete '%v' bucket: %v",
@@ -257,12 +239,6 @@ func Purge(db *bolt.DB) error {
 		if err != nil {
 			return fmt.Errorf("failed to delete '%v' k/v: %v",
 				string(LastPaymentCreatedOn), err)
-		}
-
-		err = pbkt.Delete(MinedBlocks)
-		if err != nil {
-			return fmt.Errorf("failed to delete '%v' k/v: %v",
-				string(MinedBlocks), err)
 		}
 
 		err = pbkt.Delete(SoloPool)

--- a/dividend/payment_test.go
+++ b/dividend/payment_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 
 	"github.com/dnldd/dcrpool/database"
+	"github.com/dnldd/dcrpool/util"
 )
 
 // createPersistedAccount creates a pool account with the provided parameters
@@ -44,9 +45,9 @@ func TestPayPerShare(t *testing.T) {
 	defer td()
 
 	now := time.Now()
-	nowBytes := NanoToBigEndianBytes(now.UnixNano())
+	nowBytes := util.NanoToBigEndianBytes(now.UnixNano())
 	minNano := now.Add(-(time.Second * 60)).UnixNano()
-	minBytes := NanoToBigEndianBytes(minNano)
+	minBytes := util.NanoToBigEndianBytes(minNano)
 	maxNano := now.Add(-(time.Second * 30)).UnixNano()
 	weight := new(big.Rat).SetFloat64(1.0)
 	shareCount := 10
@@ -175,9 +176,9 @@ func TestPayPerLastShare(t *testing.T) {
 	defer td()
 
 	now := time.Now()
-	nowBytes := NanoToBigEndianBytes(now.UnixNano())
+	nowBytes := util.NanoToBigEndianBytes(now.UnixNano())
 	minNano := now.Add(-(time.Second * 60)).UnixNano()
-	minBytes := NanoToBigEndianBytes(minNano)
+	minBytes := util.NanoToBigEndianBytes(minNano)
 	xAboveMinNano := now.Add(-(time.Second * 30)).UnixNano()
 	yAboveMinNano := now.Add(-(time.Second * 10)).UnixNano()
 	weight := new(big.Rat).SetFloat64(1.0)
@@ -527,7 +528,7 @@ func TestArchivedPaymentsFiltering(t *testing.T) {
 
 	now := time.Now()
 	minNano := now.Add(time.Second * 3).UnixNano()
-	minBytes := NanoToBigEndianBytes(minNano)
+	minBytes := util.NanoToBigEndianBytes(minNano)
 
 	time.Sleep(time.Second * 10)
 

--- a/dividend/share_test.go
+++ b/dividend/share_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 
 	"github.com/dnldd/dcrpool/database"
+	"github.com/dnldd/dcrpool/util"
 )
 
 var (
@@ -153,8 +154,8 @@ func TestPPSEligibleShares(t *testing.T) {
 		t.Error(err)
 	}
 
-	minNanoBytes := NanoToBigEndianBytes(minNano)
-	nowNanoBytes := NanoToBigEndianBytes(now.UnixNano())
+	minNanoBytes := util.NanoToBigEndianBytes(minNano)
+	nowNanoBytes := util.NanoToBigEndianBytes(now.UnixNano())
 	shares, err := PPSEligibleShares(db, minNanoBytes, nowNanoBytes)
 	if err != nil {
 		t.Error(err)
@@ -228,7 +229,7 @@ func TestPPLNSEligibleShares(t *testing.T) {
 		t.Error(err)
 	}
 
-	minNanoBytes := NanoToBigEndianBytes(minNano)
+	minNanoBytes := util.NanoToBigEndianBytes(minNano)
 	shares, err := PPLNSEligibleShares(db, minNanoBytes)
 	if err != nil {
 		t.Error(err)

--- a/harness.sh
+++ b/harness.sh
@@ -90,6 +90,7 @@ walletpass=${WALLET_PASS}
 poolfeeaddrs=${PFEE_ADDR}
 paymentmethod=${PAYMENT_METHOD}
 lastnperiod=${LAST_N_PERIOD}
+backuppass=b@ckUp
 EOF
 fi
 
@@ -116,6 +117,7 @@ walletpass=${WALLET_PASS}
 poolfeeaddrs=${PFEE_ADDR}
 paymentmethod=${PAYMENT_METHOD}
 lastnperiod=${LAST_N_PERIOD}
+backuppass=b@ckUp
 EOF
 
 cat > "${NODES_ROOT}/dcrwctl.conf" <<EOF
@@ -161,6 +163,7 @@ walletpass=${WALLET_PASS}
 poolfeeaddrs=${PFEE_ADDR}
 paymentmethod=${PAYMENT_METHOD}
 lastnperiod=${LAST_N_PERIOD}
+backuppass=b@ckUp
 EOF
 fi
 

--- a/network/job.go
+++ b/network/job.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/dnldd/dcrpool/dividend"
 	"github.com/dnldd/dcrpool/util"
 
 	bolt "github.com/coreos/bbolt"
@@ -28,7 +27,7 @@ type Job struct {
 func GenerateJobID(height uint32) (string, error) {
 	buf := bytes.Buffer{}
 	buf.Write(util.HeightToBigEndianBytes(height))
-	buf.Write(dividend.NanoToBigEndianBytes(time.Now().UnixNano()))
+	buf.Write(util.NanoToBigEndianBytes(time.Now().UnixNano()))
 	return hex.EncodeToString(buf.Bytes()), nil
 }
 

--- a/pool.go
+++ b/pool.go
@@ -110,7 +110,7 @@ func (p *Pool) route() {
 	p.router.Use(p.limiter.LimiterMiddleware)
 	p.router.HandleFunc("/hash", p.hub.FetchHash).Methods("GET")
 	p.router.HandleFunc("/connections", p.hub.FetchConnections).Methods("GET")
-	p.router.HandleFunc("/mined/{page}", p.hub.FetchMinedWork).Methods("GET")
+	p.router.HandleFunc("/mined", p.hub.FetchMinedWork).Methods("GET")
 	p.router.HandleFunc("/work/quotas", p.hub.FetchWorkQuotas).
 		Methods("GET")
 	p.router.HandleFunc("/work/height", p.hub.FetchLastWorkHeight).
@@ -121,6 +121,7 @@ func (p *Pool) route() {
 		p.hub.FetchMinedWorkByAccount).Methods("POST")
 	p.router.HandleFunc("/account/payments",
 		p.hub.FetchProcessedPaymentsForAccount).Methods("POST")
+	p.router.HandleFunc("/backup", p.hub.BackupDB).Methods("POST")
 }
 
 // serve starts the pool api server.
@@ -188,6 +189,7 @@ func NewPool(cfg *config) (*Pool, error) {
 		MinPayment:        minPmt,
 		PoolFeeAddrs:      cfg.poolFeeAddrs,
 		SoloPool:          cfg.SoloPool,
+		BackupPass:        cfg.BackupPass,
 	}
 
 	p.hub, err = network.NewHub(p.ctx, p.cancel, p.db, p.httpc, hcfg, p.limiter)

--- a/util/conversion.go
+++ b/util/conversion.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"time"
 )
 
 const (
@@ -96,4 +97,25 @@ func HexReversed(in string) (string, error) {
 		buf.WriteByte(in[i])
 	}
 	return buf.String(), nil
+}
+
+// NanoToBigEndianBytes returns an 8-byte big endian representation of
+// the provided nanosecond time.
+func NanoToBigEndianBytes(nano int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(nano))
+	return b
+}
+
+// BigEndianBytesToNano returns nanosecond time of the provided 8-byte big
+// endian representation.
+func BigEndianBytesToNano(b []byte) int64 {
+	return int64(binary.BigEndian.Uint64(b[0:8]))
+}
+
+// BigEndianBytesToTime returns a time instance of the provided 8-byte big
+// endian representation.
+func BigEndianBytesToTime(b []byte) *time.Time {
+	t := time.Unix(0, BigEndianBytesToNano(b))
+	return &t
 }


### PR DESCRIPTION
This reworks the mined work tracking of the pool. Accepted work when confirmed as mined are marked as such. Processed shares are now pruned after generating payments from them.

An endpoint has been added to the api for database backups. The readme has been updated with the new endpoint as well.