### PR TITLE
multi: implement realtime pool hash rate.

### DIFF
--- a/cmd/miner/client.go
+++ b/cmd/miner/client.go
@@ -119,6 +119,7 @@ func (m *Miner) connect(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			log.Info("Connection handler done.")
+			m.wg.Done()
 			return
 		default:
 			// Non-blocking receive fallthrough.
@@ -135,6 +136,7 @@ func (m *Miner) connect(ctx context.Context) {
 		conn, err := net.Dial(network.TCP, poolAddr)
 		if err != nil {
 			log.Errorf("unable connect to %s, %v", poolAddr, err)
+			time.Sleep(time.Second * 5)
 			continue
 		}
 
@@ -170,6 +172,7 @@ func (m *Miner) listen(ctx context.Context) {
 		case <-ctx.Done():
 			close(m.chainCh)
 			log.Info("Miner listener done.")
+			m.wg.Done()
 			return
 
 		default:

--- a/cmd/miner/cpuminer.go
+++ b/cmd/miner/cpuminer.go
@@ -61,6 +61,7 @@ func (m *CPUMiner) hashRateMonitor(ctx context.Context) {
 		case <-ctx.Done():
 			close(m.updateHashes)
 			log.Info("Miner hash rate monitor done.")
+			m.miner.wg.Done()
 			return
 
 		case numHashes := <-m.updateHashes:
@@ -168,6 +169,7 @@ func (m *CPUMiner) generateBlocks(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			log.Info("Miner generate blocks done.")
+			m.miner.wg.Done()
 			return
 
 		default:

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -47,16 +47,18 @@ func main() {
 		return
 	}
 
-	go miner.run(ctx)
+	go func() {
+		for {
+			select {
+			case <-interrupt:
+				miner.cancel()
 
-	for {
-		select {
-		case <-interrupt:
-			miner.cancel()
-
-		case <-ctx.Done():
-			miner.conn.Close()
-			return
+			case <-ctx.Done():
+				miner.conn.Close()
+				return
+			}
 		}
-	}
+	}()
+
+	miner.run(ctx)
 }


### PR DESCRIPTION
This tracks the hashrate of pool clients and based on the intervals between their work submissions. This also fixes a bug with the cpu miner shutdown process where terminated goroutines were not signalling the waitgroup of being done.

The cpu miner connection handler is also less aggressive in reconnecting  to the pool when it drops, it now waits 5 seconds for every retry.